### PR TITLE
Fix replace in parse_first_call_result

### DIFF
--- a/phable/auth/scram.py
+++ b/phable/auth/scram.py
@@ -160,9 +160,9 @@ def parse_first_call_result(first_call_result: HttpResponse) -> tuple[str, str, 
         )
 
     return (
-        s_nonce.replace("r=", ""),
-        salt.replace("s=", ""),
-        int(iteration_count.replace("i=", "")),
+        s_nonce.replace("r=", "", 1),
+        salt.replace("s=", "", 1),
+        int(iteration_count.replace("i=", "", 1)),
     )
 
 


### PR DESCRIPTION
Hi, I noticed when salt ends with 's=' (in my case it did), replace will remove it and that breaks the salt.
Fixed it to only replace first occurrence and just to be sure I added it to other 2 replace calls.