### PR TITLE
haystack timezones caching

### DIFF
--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, time
 import pytest
 
 import phable.kinds as kinds
-from phable.parser.json import (NotFoundError, _build_iana_tz,
+from phable.parser.json import (NotFoundError, 
                                 _haystack_to_iana_tz, _parse_coord,
                                 _parse_date, _parse_date_time, _parse_marker,
                                 _parse_na, _parse_number, _parse_ref,
@@ -110,7 +110,7 @@ def test__parse_date_time():
 
 
 def test__build_iana_tz():
-    assert _build_iana_tz("New_York") == "America/New_York"
+    assert _haystack_to_iana_tz("New_York").key == "America/New_York"
 
     with pytest.raises(NotFoundError):
-        assert _build_iana_tz("New_Yorkabc") == "America/New_York"
+        assert _haystack_to_iana_tz("New_Yorkabc").key == "America/New_York"


### PR DESCRIPTION
Hi, I was testing what takes so long when parsing data and found this in `_haystack_to_iana_tz`

https://github.com/rick-jennings/phable/blob/41679b8b19c1df847b408ae786c088227fca21c9/phable/parser/json.py#L150

For example looking for "Prague" in available_timezones always fails, iterating +-600 values for each datetime it is parsing.

I added loop that will go thru all the timezones and cache ZoneInfos in dictionary.
Then in `_haystack_to_iana_tz` I'm just looking in the cache.

Overall improvement when reading 100k rows using hisRead went down from +-50s to +-5s
