### PR TITLE
test: replace skyspark dev dependency with Haxall

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [{ name = "Rick Jennings", email = "rjennings055@gmail.com" }]
 requires-python = ">=3.11, <4"
 readme = "README.md"
 license = "MIT"
+dependencies = []
 
 [project.optional-dependencies]
 pandas = ["pandas>=2.2.3,<3"]
@@ -26,6 +27,7 @@ dev = [
     "polars>=1.34.0",
     "pyarrow>=17.0.0,<18",
     "pytest>=8.3.5",
+    "pytest-order>=1.3.0",
     "ruff>=0.11.2",
     "ty>=0.0.5",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -334,6 +334,7 @@ dev = [
     { name = "polars" },
     { name = "pyarrow" },
     { name = "pytest" },
+    { name = "pytest-order" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -353,6 +354,7 @@ dev = [
     { name = "polars", specifier = ">=1.34.0" },
     { name = "pyarrow", specifier = ">=17.0.0,<18" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-order", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.11.2" },
     { name = "ty", specifier = ">=0.0.5" },
 ]
@@ -440,6 +442,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-order"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544, upload-time = "2024-08-22T12:29:54.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609, upload-time = "2024-08-22T12:29:53.156Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Runs against Haxall-4.0.4, assumes localhost, port 8080, su/su auth
- Using pyorder to force a setup + teardown test from test_haxall_client to set up a test project db
- Where possible, fixtures have been migrated into conftest from other test modules (e.g., create_kw_point or point_id_with_his_data)
- test_haxall_client:test_configure_proj enables the 'hx.point' lib on haxall to allow hs op endpoints
- (NOTE) File op tests are commented out as these are not supported in haxall currently